### PR TITLE
Validação Estrita de Documentos e Refatoração de Processamento

### DIFF
--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -22,20 +22,20 @@ type CrossPlatformSymbol = {
 
 const SYMBOL_MAP: Record<string, CrossPlatformSymbol> = {
   // Ícones de interface
-  'folder.fill':                { ios: 'folder.fill',                android: 'folder',          web: 'folder' },
-  'chevron.down':               { ios: 'chevron.down',               android: 'expand_more',     web: 'expand_more' },
-  'chevron.right':              { ios: 'chevron.right',              android: 'chevron_right',   web: 'chevron_right' },
-  'square.and.arrow.up.fill':   { ios: 'square.and.arrow.up.fill',   android: 'share',           web: 'share' },
-  'magnifyingglass':            { ios: 'magnifyingglass',            android: 'search',          web: 'search' },
-  'eye.fill':                   { ios: 'eye.fill',                   android: 'visibility',      web: 'visibility' },
-  'trash.fill':                 { ios: 'trash.fill',                 android: 'delete',          web: 'delete' },
-  'arrow.down.doc.fill':        { ios: 'arrow.down.doc.fill',        android: 'download',        web: 'download' },
+  'folder.fill': { ios: 'folder.fill', android: 'folder', web: 'folder' },
+  'chevron.down': { ios: 'chevron.down', android: 'expand_more', web: 'expand_more' },
+  'chevron.right': { ios: 'chevron.right', android: 'chevron_right', web: 'chevron_right' },
+  'square.and.arrow.up.fill': { ios: 'square.and.arrow.up.fill', android: 'share', web: 'share' },
+  'magnifyingglass': { ios: 'magnifyingglass', android: 'search', web: 'search' },
+  'eye.fill': { ios: 'eye.fill', android: 'visibility', web: 'visibility' },
+  'trash.fill': { ios: 'trash.fill', android: 'delete', web: 'delete' },
+  'arrow.up.doc.fill': { ios: 'arrow.up.doc.fill', android: 'upload', web: 'upload' },
   // Ícones dos documentos (DEFAULT_DOCS)
-  'doc.text.fill':              { ios: 'doc.text.fill',              android: 'description',     web: 'description' },
-  'chart.bar.doc.horizontal':   { ios: 'chart.bar.doc.horizontal',   android: 'analytics',       web: 'analytics' },
-  'books.vertical.fill':        { ios: 'books.vertical.fill',        android: 'menu_book',       web: 'menu_book' },
-  'person.text.rectangle.fill': { ios: 'person.text.rectangle.fill', android: 'contact_page',    web: 'contact_page' },
-  'bus.fill':                   { ios: 'bus.fill',                   android: 'directions_bus',  web: 'directions_bus' },
+  'doc.text.fill': { ios: 'doc.text.fill', android: 'description', web: 'description' },
+  'chart.bar.doc.horizontal': { ios: 'chart.bar.doc.horizontal', android: 'analytics', web: 'analytics' },
+  'books.vertical.fill': { ios: 'books.vertical.fill', android: 'menu_book', web: 'menu_book' },
+  'person.text.rectangle.fill': { ios: 'person.text.rectangle.fill', android: 'contact_page', web: 'contact_page' },
+  'bus.fill': { ios: 'bus.fill', android: 'directions_bus', web: 'directions_bus' },
 };
 
 // Helper para obter o objeto cross-platform a partir de um nome de símbolo
@@ -59,6 +59,27 @@ interface DocumentRecord {
 
 const DEFAULT_DOCS = [
   {
+    title: "Carteirinha Estudantil",
+    description: "Comprovante oficial de vínculo com a UnB",
+    meta: "",
+    color: "#b45309",
+    symbolName: "person.text.rectangle.fill"
+  },
+  {
+    title: "Histórico Escolar",
+    description: "Todas as disciplinas cursadas",
+    meta: "",
+    color: "#7c3aed",
+    symbolName: "books.vertical.fill"
+  },
+  {
+    title: "Passe Livre Estudantil",
+    description: "Solicitação de gratuidade no transporte",
+    meta: "",
+    color: "#be185d",
+    symbolName: "bus.fill"
+  },
+  {
     title: "Boletim de Notas",
     description: "Notas das disciplinas do semestre 2026.1",
     meta: "",
@@ -71,27 +92,6 @@ const DEFAULT_DOCS = [
     meta: "",
     color: "#0e7490",
     symbolName: "chart.bar.doc.horizontal"
-  },
-  {
-    title: "Histórico Escolar",
-    description: "Todas as disciplinas cursadas",
-    meta: "",
-    color: "#7c3aed",
-    symbolName: "books.vertical.fill"
-  },
-  {
-    title: "Atestado de Matrícula",
-    description: "Comprovante oficial de vínculo com a UnB",
-    meta: "",
-    color: "#b45309",
-    symbolName: "person.text.rectangle.fill"
-  },
-  {
-    title: "Passe Livre Estudantil",
-    description: "Solicitação de gratuidade no transporte",
-    meta: "",
-    color: "#be185d",
-    symbolName: "bus.fill"
   }
 ];
 
@@ -139,7 +139,16 @@ export default function Documentos() {
   const loadDocuments = useCallback(async () => {
     try {
       await syncDefaultDocuments();
-      const result = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents ORDER BY id ASC');
+      const result = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents');
+
+      // Ordenar com base na posição em DEFAULT_DOCS
+      result.sort((a, b) => {
+        const indexA = DEFAULT_DOCS.findIndex(d => d.title === a.title);
+        const indexB = DEFAULT_DOCS.findIndex(d => d.title === b.title);
+        // Colocar no final se por acaso não achar no DEFAULT_DOCS
+        return (indexA === -1 ? 99 : indexA) - (indexB === -1 ? 99 : indexB);
+      });
+
       setDocuments(result);
       const size = result.reduce((acc, curr) => acc + (curr.size || 0), 0);
       setTotalSize(size);
@@ -154,27 +163,26 @@ export default function Documentos() {
     }, [loadDocuments])
   );
 
-  const handleBaixar = async (doc: DocumentRecord) => {
+  const handleUpload = async (doc: DocumentRecord) => {
     if (doc.uri && doc.uri !== "") {
-      Alert.alert('Aviso', 'O documento já foi baixado. Toque em "Ver" para acessá-lo.');
+      Alert.alert('Aviso', 'O documento já foi enviado. Toque em "Ver" para acessá-lo.');
       return;
     }
     try {
-      Alert.alert('Simulação de Download', 'Selecione um arquivo local para simular o download deste documento oficial do app da UnB.');
       const result = await DocumentPicker.getDocumentAsync({
         copyToCacheDirectory: true,
       });
 
       if (!result.canceled && result.assets && result.assets.length > 0) {
         const asset = result.assets[0];
-        
+
         const { processAndSaveDocument } = await import('../../../utils/documentProcessor');
-        
+
         const res = await processAndSaveDocument(
-          db, 
-          asset.uri, 
-          asset.name, 
-          asset.mimeType, 
+          db,
+          asset.uri,
+          asset.name,
+          asset.mimeType,
           asset.size,
           doc.id // Garante que ele salva exatamente no slot que o usuário clicou (ex: Declaração de Aluno Regular)
         );
@@ -182,15 +190,15 @@ export default function Documentos() {
         if (res.success) {
           Alert.alert('Documento Processado', res.message);
         } else {
-          // Se o documento foi salvo mas a extração falhou (ex: Declaração comum), avisa o usuário.
-          Alert.alert('Salvo (Sem Processamento)', res.message);
+          const title = res.message.includes('salvo') ? 'Documento Armazenado' : 'Documento não Reconhecido';
+          Alert.alert(title, res.message);
         }
 
         loadDocuments();
       }
     } catch (error) {
       console.error(error);
-      Alert.alert('Erro', 'Não foi possível baixar/salvar o arquivo.');
+      Alert.alert('Erro', 'Não foi possível fazer o upload do arquivo.');
     }
   };
 
@@ -199,7 +207,7 @@ export default function Documentos() {
       Alert.alert('Aviso', 'Este documento ainda não foi baixado.');
       return;
     }
-    
+
     try {
       if (Platform.OS === 'android') {
         const contentUri = await FileSystem.getContentUriAsync(doc.uri);
@@ -276,8 +284,8 @@ export default function Documentos() {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  const filteredDocs = documents.filter(d => 
-    d.title.toLowerCase().includes(search.toLowerCase()) || 
+  const filteredDocs = documents.filter(d =>
+    d.title.toLowerCase().includes(search.toLowerCase()) ||
     d.description.toLowerCase().includes(search.toLowerCase())
   );
   const savedDocuments = documents.filter((doc) => doc.uri && doc.uri !== "");
@@ -384,7 +392,7 @@ export default function Documentos() {
           {/* Docs List */}
           <View style={styles.docsList}>
             {filteredDocs.map((doc, index) => (
-              <DocCard 
+              <DocCard
                 key={doc.id}
                 index={index}
                 title={doc.title}
@@ -393,7 +401,7 @@ export default function Documentos() {
                 color={doc.color}
                 symbolName={doc.symbolName}
                 hasFile={!!doc.uri && doc.uri !== ""}
-                onBaixar={() => handleBaixar(doc)}
+                onUpload={() => handleUpload(doc)}
                 onVer={() => handleVer(doc)}
                 onRemover={() => handleRemover(doc)}
                 getFontSize={getFontSize}
@@ -406,14 +414,14 @@ export default function Documentos() {
   );
 }
 
-function DocCard({ title, description, meta, color, symbolName, hasFile = false, onBaixar, onVer, onRemover, getFontSize, index }: {
+function DocCard({ title, description, meta, color, symbolName, hasFile = false, onUpload, onVer, onRemover, getFontSize, index }: {
   title: string;
   description: string;
   meta: string;
   color: string;
   symbolName: string; // era SFSymbol — agora string, pois vem do banco
   hasFile?: boolean;
-  onBaixar: () => void;
+  onUpload: () => void;
   onVer: () => void;
   onRemover: () => void;
   getFontSize: (baseSize: number) => number;
@@ -442,22 +450,20 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
           <Text style={[styles.docDescription, { fontSize: getFontSize(14), color: colors.textSecondary }]}>{description}</Text>
         </View>
       </View>
-      
       {meta ? <Text style={[styles.docMeta, { fontSize: getFontSize(13), color: colors.textSecondary }]}>{meta}</Text> : null}
-      
       <View style={styles.actionsRow}>
-        <ScalePressable 
-          style={[styles.actionBtnOutline, { borderColor: btnColor, opacity: hasFile ? 1 : 0.5 }]} 
+        <ScalePressable
+          style={[styles.actionBtnOutline, { borderColor: btnColor, opacity: hasFile ? 1 : 0.5 }]}
           onPress={!hasFile ? undefined : onVer}
         >
           {/* CORRIGIDO: olho com Material Symbol no Android */}
           <SymbolView name={sym('eye.fill')} size={16} tintColor={btnColor} />
           <Text style={[styles.actionBtnOutlineText, { color: btnColor, fontSize: getFontSize(15) }]}>Ver</Text>
         </ScalePressable>
-        
+
         {hasFile ? (
-          <ScalePressable 
-            style={[styles.actionBtnSolid, { backgroundColor: "#ef4444" }]} 
+          <ScalePressable
+            style={[styles.actionBtnSolid, { backgroundColor: "#ef4444" }]}
             onPress={onRemover}
           >
             {/* CORRIGIDO: lixeira com Material Symbol no Android */}
@@ -465,13 +471,13 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
             <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Remover</Text>
           </ScalePressable>
         ) : (
-          <ScalePressable 
-            style={[styles.actionBtnSolid, { backgroundColor: btnColor }]} 
-            onPress={onBaixar}
+          <ScalePressable
+            style={[styles.actionBtnSolid, { backgroundColor: btnColor }]}
+            onPress={onUpload}
           >
-            {/* CORRIGIDO: download com Material Symbol no Android */}
-            <SymbolView name={sym('arrow.down.doc.fill')} size={16} tintColor="#fff" />
-            <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Baixar</Text>
+            {/* CORRIGIDO: upload com Material Symbol no Android */}
+            <SymbolView name={sym('arrow.up.doc.fill')} size={16} tintColor="#fff" />
+            <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Upload</Text>
           </ScalePressable>
         )}
       </View>

--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -60,7 +60,7 @@ interface DocumentRecord {
 const DEFAULT_DOCS = [
   {
     title: "Carteirinha Estudantil",
-    description: "Comprovante oficial de vínculo com a UnB",
+    description: "Identificação oficial do estudante",
     meta: "",
     color: "#b45309",
     symbolName: "person.text.rectangle.fill"

--- a/UnB-App/utils/documentProcessor.ts
+++ b/UnB-App/utils/documentProcessor.ts
@@ -18,13 +18,13 @@ export async function processAndSaveDocument(
 ): Promise<{ success: boolean; message: string }> {
   try {
     const extractResult = await extractTextWithInfo(fileUri);
-    
+
     if (!extractResult.success) {
       return { success: false, message: 'Falha ao extrair texto do PDF. Tente novamente ou use outro arquivo.' };
     }
 
     const text = extractResult.text;
-    
+
     // Funções lazy para não rodar todos os includes desnecessariamente
     const checkHistorico = () => text.includes('Histórico Escolar');
     const checkPasseLivre = () => text.includes('PASSE LIVRE ESTUDANTIL') || text.includes('Passe Livre');
@@ -39,26 +39,26 @@ export async function processAndSaveDocument(
       let docRecord: { id: number, title: string } | null = null;
 
       if (overrideDocId) {
-        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE id = ?', [overrideDocId]);
-        
+        docRecord = await db.getFirstAsync<{ id: number, title: string }>('SELECT id, title FROM documents WHERE id = ?', [overrideDocId]);
+
         // Validação estrita (somente testa a regra do slot atual)
         if (docRecord) {
-           if (docRecord.title === "Histórico Escolar" && !checkHistorico()) {
-               return { success: false, message: 'O arquivo que você enviou não parece ser um Histórico Escolar. Confira se selecionou o PDF correto.' };
-           }
-           if (docRecord.title === "Passe Livre Estudantil" && !checkPasseLivre()) {
-               return { success: false, message: 'O arquivo que você enviou não parece ser o Passe Livre Estudantil. Confira se selecionou o PDF correto.' };
-           }
-           if (docRecord.title === "Boletim de Notas" && !checkBoletim()) {
-               return { success: false, message: 'O arquivo que você enviou não parece ser o Boletim de Notas. Confira se selecionou o PDF correto.' };
-           }
-           if (docRecord.title === "Índice Acadêmico" && !checkIndice()) {
-               return { success: false, message: 'O arquivo que você enviou não parece ser o Índice Acadêmico. Confira se selecionou o PDF correto.' };
-           }
-           if (docRecord.title === "Carteirinha Estudantil" && !checkCarteirinha()) {
-               return { success: false, message: 'O arquivo que você enviou não parece ser a Carteirinha Estudantil. Confira se selecionou o PDF correto.' };
-           }
-           finalDocTitle = docRecord.title;
+          if (docRecord.title === "Histórico Escolar" && !checkHistorico()) {
+            return { success: false, message: 'O arquivo que você enviou não parece ser um Histórico Escolar. Confira se selecionou o PDF correto.' };
+          }
+          if (docRecord.title === "Passe Livre Estudantil" && !checkPasseLivre()) {
+            return { success: false, message: 'O arquivo que você enviou não parece ser o Passe Livre Estudantil. Confira se selecionou o PDF correto.' };
+          }
+          if (docRecord.title === "Boletim de Notas" && !checkBoletim()) {
+            return { success: false, message: 'O arquivo que você enviou não parece ser o Boletim de Notas. Confira se selecionou o PDF correto.' };
+          }
+          if (docRecord.title === "Índice Acadêmico" && !checkIndice()) {
+            return { success: false, message: 'O arquivo que você enviou não parece ser o Índice Acadêmico. Confira se selecionou o PDF correto.' };
+          }
+          if (docRecord.title === "Carteirinha Estudantil" && !checkCarteirinha()) {
+            return { success: false, message: 'O arquivo que você enviou não parece ser a Carteirinha Estudantil. Confira se selecionou o PDF correto.' };
+          }
+          finalDocTitle = docRecord.title;
         }
       } else {
         // Se inserido pelo botão genérico, testa na ordem até achar
@@ -67,23 +67,23 @@ export async function processAndSaveDocument(
         else if (checkCarteirinha()) finalDocTitle = "Carteirinha Estudantil";
         else if (checkBoletim()) finalDocTitle = "Boletim de Notas";
         else if (checkIndice()) finalDocTitle = "Índice Acadêmico";
-        
+
         if (!finalDocTitle) {
           return { success: false, message: 'Não conseguimos identificar este documento. Por favor, envie um documento oficial gerado pelo SIGAA da UnB.' };
         }
 
-        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [finalDocTitle]);
+        docRecord = await db.getFirstAsync<{ id: number, title: string }>('SELECT id, title FROM documents WHERE title = ?', [finalDocTitle]);
       }
-      
+
       if (docRecord) {
         const extension = fileName?.split('.').pop()?.toUpperCase() || 'ARQUIVO';
         const newMeta = `Importado em ${new Date().toLocaleDateString('pt-BR')} · ${extension}`;
-        
+
         let newUri = "";
         if (FileSystem) {
-           const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
-           newUri = FileSystem.documentDirectory + finalFileName;
-           await FileSystem.copyAsync({ from: fileUri, to: newUri });
+          const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
+          newUri = FileSystem.documentDirectory + finalFileName;
+          await FileSystem.copyAsync({ from: fileUri, to: newUri });
         }
 
         await db.runAsync(
@@ -93,13 +93,12 @@ export async function processAndSaveDocument(
 
         // Bloqueia processamento indevido de documentos "burros"
         if (finalDocTitle !== "Histórico Escolar" && finalDocTitle !== "Passe Livre Estudantil") {
-           return { success: false, message: 'Documento salvo.' };
+          return { success: false, message: 'Documento salvo.' };
         }
       }
     } catch (err) {
       console.error('Erro ao salvar documento no storage permanente:', err);
     }
-    
     // Helper para prosseguir com a lógica de sync
     const attemptSync = async (alunoInfo: any, disciplinasFormatadas: any, successMessage: string) => {
       let proceed = true;
@@ -125,7 +124,7 @@ export async function processAndSaveDocument(
     if (finalDocTitle === "Histórico Escolar") {
       const { extrairDadosDoHistorico } = await import('./historicoParser');
       const parsedData = extrairDadosDoHistorico(text);
-      
+
       if (!parsedData || parsedData.disciplinas.length === 0) {
         return { success: false, message: 'Conseguimos ler o Histórico, mas não encontramos nenhuma disciplina cursada nele.' };
       }
@@ -175,14 +174,18 @@ export async function processAndSaveDocument(
 
       return await attemptSync(alunoInfo, disciplinasFormatadas, `Grade atualizada via Histórico Escolar (Semestre ${maxAno}.${maxPeriodo})! O arquivo foi salvo na aba Documentos.`);
 
-    } else {
-      // Se não for Histórico, assume que é Passe Livre
+    } else if (finalDocTitle === "Passe Livre Estudantil") {
+      // Se for Passe Livre
       const { aluno, disciplinas: parsedDisciplinas } = extrairDadosDoPDF(text);
       if (parsedDisciplinas.length === 0) {
         return { success: false, message: 'Conseguimos ler o Passe Livre, mas não encontramos nenhuma disciplina matriculada.' };
       }
 
       return await attemptSync(aluno, parsedDisciplinas, 'Grade importada com sucesso via Declaração/Passe Livre! O arquivo foi salvo na aba Documentos.');
+      
+    } else if (finalDocTitle === "Carteirinha Estudantil") {
+      // O usuário solicitou que a carteirinha apenas seja armazenada, sem extração de dados
+      return { success: true, message: 'Documento salvo.' };
     }
   } catch (error: any) {
     return { success: false, message: `Ocorreu um erro inesperado ao processar o arquivo: ${error.message}` };

--- a/UnB-App/utils/documentProcessor.ts
+++ b/UnB-App/utils/documentProcessor.ts
@@ -24,9 +24,16 @@ export async function processAndSaveDocument(
     }
 
     const text = extractResult.text;
-    const isHistorico = text.includes('Histórico Escolar');
-    const isPasseLivre = text.includes('PASSE LIVRE ESTUDANTIL') || text.includes('Passe Livre');
     
+    // Funções lazy para não rodar todos os includes desnecessariamente
+    const checkHistorico = () => text.includes('Histórico Escolar');
+    const checkPasseLivre = () => text.includes('PASSE LIVRE ESTUDANTIL') || text.includes('Passe Livre');
+    const checkBoletim = () => text.includes('RELATÓRIO DE NOTAS') || text.includes('Boletim de Notas');
+    const checkIndice = () => text.includes('ÍNDICES ACADÊMICOS') || text.includes('Índice de Rendimento Acadêmico');
+    const checkCarteirinha = () => text.includes('VALIDADE') && (text.includes('Secretário de Administração Acadêmica') || text.includes('Secretaria de Administração Acadêmica'));
+
+    let finalDocTitle = "";
+
     // Salvar o arquivo na tabela de documentos
     try {
       let docRecord: { id: number, title: string } | null = null;
@@ -34,18 +41,38 @@ export async function processAndSaveDocument(
       if (overrideDocId) {
         docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE id = ?', [overrideDocId]);
         
-        // Validação estrita de tipo de documento
+        // Validação estrita (somente testa a regra do slot atual)
         if (docRecord) {
-           if (docRecord.title === "Histórico Escolar" && !isHistorico) {
-               return { success: false, message: 'O arquivo enviado não parece ser um Histórico Escolar. Verifique se escolheu o slot correto.' };
+           if (docRecord.title === "Histórico Escolar" && !checkHistorico()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser um Histórico Escolar. Confira se selecionou o PDF correto.' };
            }
-           if (docRecord.title === "Passe Livre Estudantil" && !isPasseLivre) {
-               return { success: false, message: 'O arquivo enviado não parece ser um Passe Livre Estudantil. Verifique se escolheu o slot correto.' };
+           if (docRecord.title === "Passe Livre Estudantil" && !checkPasseLivre()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Passe Livre Estudantil. Confira se selecionou o PDF correto.' };
            }
+           if (docRecord.title === "Boletim de Notas" && !checkBoletim()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Boletim de Notas. Confira se selecionou o PDF correto.' };
+           }
+           if (docRecord.title === "Índice Acadêmico" && !checkIndice()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Índice Acadêmico. Confira se selecionou o PDF correto.' };
+           }
+           if (docRecord.title === "Carteirinha Estudantil" && !checkCarteirinha()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser a Carteirinha Estudantil. Confira se selecionou o PDF correto.' };
+           }
+           finalDocTitle = docRecord.title;
         }
       } else {
-        const docTitle = isHistorico ? "Histórico Escolar" : "Passe Livre Estudantil";
-        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [docTitle]);
+        // Se inserido pelo botão genérico, testa na ordem até achar
+        if (checkHistorico()) finalDocTitle = "Histórico Escolar";
+        else if (checkPasseLivre()) finalDocTitle = "Passe Livre Estudantil";
+        else if (checkCarteirinha()) finalDocTitle = "Carteirinha Estudantil";
+        else if (checkBoletim()) finalDocTitle = "Boletim de Notas";
+        else if (checkIndice()) finalDocTitle = "Índice Acadêmico";
+        
+        if (!finalDocTitle) {
+          return { success: false, message: 'Não conseguimos identificar este documento. Por favor, envie um documento oficial gerado pelo SIGAA da UnB.' };
+        }
+
+        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [finalDocTitle]);
       }
       
       if (docRecord) {
@@ -54,9 +81,9 @@ export async function processAndSaveDocument(
         
         let newUri = "";
         if (FileSystem) {
-          const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
-          newUri = FileSystem.documentDirectory + finalFileName;
-          await FileSystem.copyAsync({ from: fileUri, to: newUri });
+           const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
+           newUri = FileSystem.documentDirectory + finalFileName;
+           await FileSystem.copyAsync({ from: fileUri, to: newUri });
         }
 
         await db.runAsync(
@@ -64,10 +91,9 @@ export async function processAndSaveDocument(
           [newUri, fileName || 'documento.pdf', mimeType || 'application/pdf', size || 0, newMeta, docRecord.id]
         );
 
-        // Se a chamada veio da aba Documentos (tem overrideDocId) e é um slot "burro",
-        // paramos a execução aqui. Ele salva o arquivo e não altera o banco de dados.
-        if (overrideDocId && docRecord.title !== "Histórico Escolar" && docRecord.title !== "Passe Livre Estudantil") {
-           return { success: false, message: 'Documento salvo (Sem Processamento Automático).' };
+        // Bloqueia processamento indevido de documentos "burros"
+        if (finalDocTitle !== "Histórico Escolar" && finalDocTitle !== "Passe Livre Estudantil") {
+           return { success: false, message: 'Documento salvo.' };
         }
       }
     } catch (err) {
@@ -95,13 +121,13 @@ export async function processAndSaveDocument(
       return { success: true, message: successMessage };
     };
 
-    // Detecção automática de qual documento foi enviado
-    if (isHistorico) {
+    // Detecção automática de qual documento foi enviado (apenas Histórico e Passe Livre chegam aqui)
+    if (finalDocTitle === "Histórico Escolar") {
       const { extrairDadosDoHistorico } = await import('./historicoParser');
       const parsedData = extrairDadosDoHistorico(text);
       
       if (!parsedData || parsedData.disciplinas.length === 0) {
-        return { success: false, message: 'Não foi possível encontrar disciplinas válidas neste Histórico.' };
+        return { success: false, message: 'Conseguimos ler o Histórico, mas não encontramos nenhuma disciplina cursada nele.' };
       }
 
       // Descobrir qual é o semestre atual (o maior ano/periodo do histórico)
@@ -153,12 +179,12 @@ export async function processAndSaveDocument(
       // Se não for Histórico, assume que é Passe Livre
       const { aluno, disciplinas: parsedDisciplinas } = extrairDadosDoPDF(text);
       if (parsedDisciplinas.length === 0) {
-        return { success: false, message: 'Não foi possível encontrar disciplinas válidas neste PDF.' };
+        return { success: false, message: 'Conseguimos ler o Passe Livre, mas não encontramos nenhuma disciplina matriculada.' };
       }
 
       return await attemptSync(aluno, parsedDisciplinas, 'Grade importada com sucesso via Declaração/Passe Livre! O arquivo foi salvo na aba Documentos.');
     }
   } catch (error: any) {
-    return { success: false, message: `Erro ao processar o arquivo: ${error.message}` };
+    return { success: false, message: `Ocorreu um erro inesperado ao processar o arquivo: ${error.message}` };
   }
 }


### PR DESCRIPTION
## 📝 Descrição do PR

Este Pull Request implementa os requisitos da Iteração 2, garantindo que o motor de processamento de documentos seja robusto contra envios incorretos de PDF pelos usuários (ex: enviar Histórico no slot de Carteirinha). Adicionalmente, as interfaces foram revisadas para melhor usabilidade, com foco em "Upload" de documentos, e a arquitetura de processamento e persistência (SQLite) foi aprimorada.

## 🚀 O que foi alterado?

- **Refatoração da Nomenclatura & Banco de Dados:** 
  - Substituição do documento "Atestado de Matrícula" pela **"Carteirinha Estudantil"** (Descrição: "Identificação oficial do estudante").
  - Atualização do hook `syncDefaultDocuments` para realizar um `UPDATE` nos documentos padrões (garantindo que se o nome ou descrição for atualizado no código, os metadados no SQLite local dos usuários que já possuem o app serão atualizados em tempo real).
- **Adequação da UI (documents.tsx):** 
  - Correção na ordenação da lista de documentos (respeitando a constante `DEFAULT_DOCS` em vez do ID de banco).
  - Renomeação dos botões e fluxos de "Baixar" para "Upload", alterando os ícones para `arrow.up.doc.fill`, pois o fluxo real consiste no aluno inserindo um arquivo no app, e não baixando.
  - Remoção de alertas redundantes nativos (simulação de download) antes de abrir o explorador de arquivos.
- **Validação Estrita & Lazy Evaluation (documentProcessor.ts):**
  - Implementada validação para bloquear o processamento caso o usuário insira um documento num slot (card) incorreto.
  - Funções de checagem textuais criadas de forma *lazy* (só checam as palavras-chave necessárias da string gigante se acionadas), economizando tempo de CPU do mobile.
  - Os textos de notificação foram revisados para serem mais amigáveis e explicativos (ex: "O arquivo que você enviou não parece ser a Carteirinha...").

## 🎯 Requisitos Atendidos
- [x] RF04 - Armazenar Dados de Documentos Enviados
- [x] RF05 - Processar Dados de Documentos Enviados
- [x] RNF03 - Permitir Consulta de Informações Institucionais Offline
- [x] RNF08 - Armazenar Dados Locais com Expo SQLite

## 🧪 Como Testar

1. Acesse a aba **Documentos**. Note a alteração dos nomes e botões de "Baixar" para "Upload".
2. Toque em **Upload** no card de "Histórico Escolar" e envie um PDF de *Carteirinha Estudantil* propositalmente. O App deve disparar um alerta amigável bloqueando a inserção por não ser o arquivo correto.
3. Repita o upload da *Carteirinha Estudantil* no slot correto (primeiro da lista). O App deve disparar uma mensagem de sucesso confirmando a identificação oficial e salvando o documento.
4. Reinicie o aplicativo para certificar-se de que a sincronização automática (`syncDefaultDocuments`) atualiza nomes de documentos e posições do SQLite sem problemas.
