### PR TITLE
Adição da Carteirinha Estudantil, Refatoração e Sincronização do Upload de Documentos

### DIFF
--- a/UnB-App/src/app/(tabs)/disciplinas.tsx
+++ b/UnB-App/src/app/(tabs)/disciplinas.tsx
@@ -9,7 +9,7 @@ import { extrairDadosDoPDF } from '../../../utils/pdfParser';
 import * as DocumentPicker from 'expo-document-picker';
 import { extractTextWithInfo } from 'expo-pdf-text-extract';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useFocusEffect } from 'expo-router';
 import { useTextSize } from "@/contexts/TextSizeContext";
 import { useTheme } from '@/contexts/ThemeContext';
 import { SymbolView } from "expo-symbols";
@@ -136,10 +136,12 @@ export default function DisciplinasScreen() {
     }
   };
 
-  // NOTE: removed useFocusEffect from expo-router, using useEffect or fallback
-  useEffect(() => {
-    carregarDisciplinas();
-  }, [carregarDisciplinas]);
+  // Restabelecido useFocusEffect para que atualizações da aba Documentos reflitam aqui imediatamente.
+  useFocusEffect(
+    useCallback(() => {
+      carregarDisciplinas();
+    }, [carregarDisciplinas])
+  );
 
   const filteredDisciplinas = disciplinas.filter(d =>
     d.nome_disciplina.toLowerCase().includes(search.toLowerCase()) ||

--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -22,22 +22,20 @@ type CrossPlatformSymbol = {
 
 const SYMBOL_MAP: Record<string, CrossPlatformSymbol> = {
   // Ícones de interface
-  'folder.fill':                { ios: 'folder.fill',                android: 'folder',          web: 'folder' },
-  'chevron.down':               { ios: 'chevron.down',               android: 'expand_more',     web: 'expand_more' },
-  'chevron.right':              { ios: 'chevron.right',              android: 'chevron_right',   web: 'chevron_right' },
-  'square.and.arrow.up.fill':   { ios: 'square.and.arrow.up.fill',   android: 'share',           web: 'share' },
-  'magnifyingglass':            { ios: 'magnifyingglass',            android: 'search',          web: 'search' },
-  'eye.fill':                   { ios: 'eye.fill',                   android: 'visibility',      web: 'visibility' },
-  'trash.fill':                 { ios: 'trash.fill',                 android: 'delete',          web: 'delete' },
-  'arrow.down.doc.fill':        { ios: 'arrow.down.doc.fill',        android: 'download',        web: 'download' },
-  'icloud.and.arrow.up.fill':   { ios: 'icloud.and.arrow.up.fill',   android: 'cloud_upload',    web: 'cloud_upload' },
-  'person.crop.square.fill':    { ios: 'person.crop.square.fill',    android: 'badge',           web: 'badge' },
+  'folder.fill': { ios: 'folder.fill', android: 'folder', web: 'folder' },
+  'chevron.down': { ios: 'chevron.down', android: 'expand_more', web: 'expand_more' },
+  'chevron.right': { ios: 'chevron.right', android: 'chevron_right', web: 'chevron_right' },
+  'square.and.arrow.up.fill': { ios: 'square.and.arrow.up.fill', android: 'share', web: 'share' },
+  'magnifyingglass': { ios: 'magnifyingglass', android: 'search', web: 'search' },
+  'eye.fill': { ios: 'eye.fill', android: 'visibility', web: 'visibility' },
+  'trash.fill': { ios: 'trash.fill', android: 'delete', web: 'delete' },
+  'arrow.up.doc.fill': { ios: 'arrow.up.doc.fill', android: 'upload', web: 'upload' },
   // Ícones dos documentos (DEFAULT_DOCS)
-  'doc.text.fill':              { ios: 'doc.text.fill',              android: 'description',     web: 'description' },
-  'chart.bar.doc.horizontal':   { ios: 'chart.bar.doc.horizontal',   android: 'analytics',       web: 'analytics' },
-  'books.vertical.fill':        { ios: 'books.vertical.fill',        android: 'menu_book',       web: 'menu_book' },
-  'person.text.rectangle.fill': { ios: 'person.text.rectangle.fill', android: 'contact_page',    web: 'contact_page' },
-  'bus.fill':                   { ios: 'bus.fill',                   android: 'directions_bus',  web: 'directions_bus' },
+  'doc.text.fill': { ios: 'doc.text.fill', android: 'description', web: 'description' },
+  'chart.bar.doc.horizontal': { ios: 'chart.bar.doc.horizontal', android: 'analytics', web: 'analytics' },
+  'books.vertical.fill': { ios: 'books.vertical.fill', android: 'menu_book', web: 'menu_book' },
+  'person.text.rectangle.fill': { ios: 'person.text.rectangle.fill', android: 'contact_page', web: 'contact_page' },
+  'bus.fill': { ios: 'bus.fill', android: 'directions_bus', web: 'directions_bus' },
 };
 
 // Helper para obter o objeto cross-platform a partir de um nome de símbolo
@@ -62,10 +60,10 @@ interface DocumentRecord {
 const DEFAULT_DOCS = [
   {
     title: "Carteirinha Estudantil",
-    description: "Documento de identificação com foto",
+    description: "Comprovante oficial de vínculo com a UnB",
     meta: "",
-    color: "#2563eb",
-    symbolName: "person.crop.square.fill"
+    color: "#b45309",
+    symbolName: "person.text.rectangle.fill"
   },
   {
     title: "Histórico Escolar",
@@ -94,13 +92,6 @@ const DEFAULT_DOCS = [
     meta: "",
     color: "#0e7490",
     symbolName: "chart.bar.doc.horizontal"
-  },
-  {
-    title: "Atestado de Matrícula",
-    description: "Comprovante oficial de vínculo com a UnB",
-    meta: "",
-    color: "#b45309",
-    symbolName: "person.text.rectangle.fill"
   }
 ];
 
@@ -149,13 +140,15 @@ export default function Documentos() {
     try {
       await syncDefaultDocuments();
       const result = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents');
-      // Ordena de acordo com o index de DEFAULT_DOCS
-      const defaultOrder = DEFAULT_DOCS.map(d => d.title);
+
+      // Ordenar com base na posição em DEFAULT_DOCS
       result.sort((a, b) => {
-        const indexA = defaultOrder.indexOf(a.title);
-        const indexB = defaultOrder.indexOf(b.title);
-        return (indexA === -1 ? 999 : indexA) - (indexB === -1 ? 999 : indexB);
+        const indexA = DEFAULT_DOCS.findIndex(d => d.title === a.title);
+        const indexB = DEFAULT_DOCS.findIndex(d => d.title === b.title);
+        // Colocar no final se por acaso não achar no DEFAULT_DOCS
+        return (indexA === -1 ? 99 : indexA) - (indexB === -1 ? 99 : indexB);
       });
+
       setDocuments(result);
       const size = result.reduce((acc, curr) => acc + (curr.size || 0), 0);
       setTotalSize(size);
@@ -170,27 +163,26 @@ export default function Documentos() {
     }, [loadDocuments])
   );
 
-  const handleBaixar = async (doc: DocumentRecord) => {
+  const handleUpload = async (doc: DocumentRecord) => {
     if (doc.uri && doc.uri !== "") {
-      Alert.alert('Aviso', 'O documento já foi carregado. Toque em "Ver" para acessá-lo.');
+      Alert.alert('Aviso', 'O documento já foi enviado. Toque em "Ver" para acessá-lo.');
       return;
     }
     try {
-      Alert.alert('Upload de Documento', 'Selecione um arquivo local para fazer o upload deste documento para o app.');
       const result = await DocumentPicker.getDocumentAsync({
         copyToCacheDirectory: true,
       });
 
       if (!result.canceled && result.assets && result.assets.length > 0) {
         const asset = result.assets[0];
-        
+
         const { processAndSaveDocument } = await import('../../../utils/documentProcessor');
-        
+
         const res = await processAndSaveDocument(
-          db, 
-          asset.uri, 
-          asset.name, 
-          asset.mimeType, 
+          db,
+          asset.uri,
+          asset.name,
+          asset.mimeType,
           asset.size,
           doc.id // Garante que ele salva exatamente no slot que o usuário clicou (ex: Declaração de Aluno Regular)
         );
@@ -198,24 +190,24 @@ export default function Documentos() {
         if (res.success) {
           Alert.alert('Documento Processado', res.message);
         } else {
-          // Se o documento foi salvo mas a extração falhou (ex: Declaração comum), avisa o usuário.
-          Alert.alert('Salvo (Sem Processamento)', res.message);
+          const title = res.message.includes('salvo') ? 'Documento Armazenado' : 'Documento não Reconhecido';
+          Alert.alert(title, res.message);
         }
 
         loadDocuments();
       }
     } catch (error) {
       console.error(error);
-      Alert.alert('Erro', 'Não foi possível fazer o upload ou salvar o arquivo.');
+      Alert.alert('Erro', 'Não foi possível fazer o upload do arquivo.');
     }
   };
 
   const handleVer = async (doc: DocumentRecord) => {
     if (!doc.uri || doc.uri === "") {
-      Alert.alert('Aviso', 'Este documento ainda não foi carregado.');
+      Alert.alert('Aviso', 'Este documento ainda não foi baixado.');
       return;
     }
-    
+
     try {
       if (Platform.OS === 'android') {
         const contentUri = await FileSystem.getContentUriAsync(doc.uri);
@@ -292,8 +284,8 @@ export default function Documentos() {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  const filteredDocs = documents.filter(d => 
-    d.title.toLowerCase().includes(search.toLowerCase()) || 
+  const filteredDocs = documents.filter(d =>
+    d.title.toLowerCase().includes(search.toLowerCase()) ||
     d.description.toLowerCase().includes(search.toLowerCase())
   );
   const savedDocuments = documents.filter((doc) => doc.uri && doc.uri !== "");
@@ -400,7 +392,7 @@ export default function Documentos() {
           {/* Docs List */}
           <View style={styles.docsList}>
             {filteredDocs.map((doc, index) => (
-              <DocCard 
+              <DocCard
                 key={doc.id}
                 index={index}
                 title={doc.title}
@@ -409,7 +401,7 @@ export default function Documentos() {
                 color={doc.color}
                 symbolName={doc.symbolName}
                 hasFile={!!doc.uri && doc.uri !== ""}
-                onBaixar={() => handleBaixar(doc)}
+                onUpload={() => handleUpload(doc)}
                 onVer={() => handleVer(doc)}
                 onRemover={() => handleRemover(doc)}
                 getFontSize={getFontSize}
@@ -422,14 +414,14 @@ export default function Documentos() {
   );
 }
 
-function DocCard({ title, description, meta, color, symbolName, hasFile = false, onBaixar, onVer, onRemover, getFontSize, index }: {
+function DocCard({ title, description, meta, color, symbolName, hasFile = false, onUpload, onVer, onRemover, getFontSize, index }: {
   title: string;
   description: string;
   meta: string;
   color: string;
   symbolName: string; // era SFSymbol — agora string, pois vem do banco
   hasFile?: boolean;
-  onBaixar: () => void;
+  onUpload: () => void;
   onVer: () => void;
   onRemover: () => void;
   getFontSize: (baseSize: number) => number;
@@ -458,22 +450,20 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
           <Text style={[styles.docDescription, { fontSize: getFontSize(14), color: colors.textSecondary }]}>{description}</Text>
         </View>
       </View>
-      
       {meta ? <Text style={[styles.docMeta, { fontSize: getFontSize(13), color: colors.textSecondary }]}>{meta}</Text> : null}
-      
       <View style={styles.actionsRow}>
-        <ScalePressable 
-          style={[styles.actionBtnOutline, { borderColor: btnColor, opacity: hasFile ? 1 : 0.5 }]} 
+        <ScalePressable
+          style={[styles.actionBtnOutline, { borderColor: btnColor, opacity: hasFile ? 1 : 0.5 }]}
           onPress={!hasFile ? undefined : onVer}
         >
           {/* CORRIGIDO: olho com Material Symbol no Android */}
           <SymbolView name={sym('eye.fill')} size={16} tintColor={btnColor} />
           <Text style={[styles.actionBtnOutlineText, { color: btnColor, fontSize: getFontSize(15) }]}>Ver</Text>
         </ScalePressable>
-        
+
         {hasFile ? (
-          <ScalePressable 
-            style={[styles.actionBtnSolid, { backgroundColor: "#ef4444" }]} 
+          <ScalePressable
+            style={[styles.actionBtnSolid, { backgroundColor: "#ef4444" }]}
             onPress={onRemover}
           >
             {/* CORRIGIDO: lixeira com Material Symbol no Android */}
@@ -481,12 +471,12 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
             <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Remover</Text>
           </ScalePressable>
         ) : (
-          <ScalePressable 
-            style={[styles.actionBtnSolid, { backgroundColor: btnColor }]} 
-            onPress={onBaixar}
+          <ScalePressable
+            style={[styles.actionBtnSolid, { backgroundColor: btnColor }]}
+            onPress={onUpload}
           >
             {/* CORRIGIDO: upload com Material Symbol no Android */}
-            <SymbolView name={sym('icloud.and.arrow.up.fill')} size={16} tintColor="#fff" />
+            <SymbolView name={sym('arrow.up.doc.fill')} size={16} tintColor="#fff" />
             <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Upload</Text>
           </ScalePressable>
         )}

--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react';
-import { ScrollView, Text, View, StyleSheet, TextInput, Platform, Alert } from "react-native";
+import { ScrollView, Text, View, StyleSheet, TextInput, Platform, Alert, ActivityIndicator } from "react-native";
 import ScalePressable from "@/components/ScalePressable";
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -11,6 +11,7 @@ import * as Sharing from 'expo-sharing';
 import * as IntentLauncher from 'expo-intent-launcher';
 import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useUserProfile } from '@/contexts/UserProfileContext';
 import { useFocusEffect } from 'expo-router';
 
 // Mapeamento: SF Symbol (iOS) → Material Symbol (Android / Web)
@@ -99,10 +100,12 @@ export default function Documentos() {
   const db = useSQLiteContext();
   const { getFontSize } = useTextSize();
   const { colors, isDark } = useTheme();
+  const { userName, userMatricula, autoSyncPDFData, updateUserProfile } = useUserProfile();
   const [documents, setDocuments] = useState<DocumentRecord[]>([]);
   const [search, setSearch] = useState("");
   const [totalSize, setTotalSize] = useState(0);
   const [showSavedDocuments, setShowSavedDocuments] = useState(false);
+  const [processingId, setProcessingId] = useState<number | null>(null);
 
   const syncDefaultDocuments = useCallback(async () => {
     const existing = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents');
@@ -178,23 +181,65 @@ export default function Documentos() {
 
         const { processAndSaveDocument } = await import('../../../utils/documentProcessor');
 
-        const res = await processAndSaveDocument(
-          db,
-          asset.uri,
-          asset.name,
-          asset.mimeType,
-          asset.size,
-          doc.id // Garante que ele salva exatamente no slot que o usuário clicou (ex: Declaração de Aluno Regular)
-        );
+        setProcessingId(doc.id);
+        try {
+          const res = await processAndSaveDocument(
+            db,
+            asset.uri,
+            asset.name,
+            asset.mimeType,
+            asset.size,
+            doc.id, // Garante que ele salva exatamente no slot que o usuário clicou (ex: Declaração de Aluno Regular)
+            {
+              onConfirmProfileSync: async (aluno) => {
+                let proceed = true;
+                let shouldSync = autoSyncPDFData;
+                
+                if (aluno && userMatricula && userMatricula !== aluno.matricula) {
+                   proceed = await new Promise((resolve) => {
+                      Alert.alert(
+                        "Documento Inconsistente",
+                        `Este documento pertence a ${aluno.nome} (${aluno.matricula}), que é diferente do seu perfil. Deseja realmente importar?`,
+                        [
+                          { text: "Cancelar", style: "cancel", onPress: () => resolve(false) },
+                          { text: "Importar", style: "destructive", onPress: () => resolve(true) }
+                        ]
+                      );
+                   });
 
-        if (res.success) {
-          Alert.alert('Documento Processado', res.message);
-        } else {
-          const title = res.message.includes('salvo') ? 'Documento Armazenado' : 'Documento não Reconhecido';
-          Alert.alert(title, res.message);
+                   if (proceed) {
+                      shouldSync = await new Promise((resolve) => {
+                         Alert.alert(
+                           "Atualizar Perfil",
+                           "Deseja atualizar seu perfil para usar os dados deste documento?",
+                           [
+                             { text: "Não alterar", style: "cancel", onPress: () => resolve(false) },
+                             { text: "Atualizar", onPress: () => resolve(true) }
+                           ]
+                         );
+                      });
+                   }
+                } else if (!userMatricula && aluno) {
+                   shouldSync = true;
+                }
+
+                return { proceed, shouldSync };
+              },
+              updateUserProfile
+            }
+          );
+
+          if (res.success) {
+            Alert.alert('Documento Processado', res.message);
+          } else {
+            const title = res.message.includes('salvo') ? 'Documento Armazenado' : 'Documento não Reconhecido';
+            Alert.alert(title, res.message);
+          }
+
+          loadDocuments();
+        } finally {
+          setProcessingId(null);
         }
-
-        loadDocuments();
       }
     } catch (error) {
       console.error(error);
@@ -401,6 +446,7 @@ export default function Documentos() {
                 color={doc.color}
                 symbolName={doc.symbolName}
                 hasFile={!!doc.uri && doc.uri !== ""}
+                isProcessing={processingId === doc.id}
                 onUpload={() => handleUpload(doc)}
                 onVer={() => handleVer(doc)}
                 onRemover={() => handleRemover(doc)}
@@ -414,13 +460,14 @@ export default function Documentos() {
   );
 }
 
-function DocCard({ title, description, meta, color, symbolName, hasFile = false, onUpload, onVer, onRemover, getFontSize, index }: {
+function DocCard({ title, description, meta, color, symbolName, hasFile = false, isProcessing = false, onUpload, onVer, onRemover, getFontSize, index }: {
   title: string;
   description: string;
   meta: string;
   color: string;
   symbolName: string; // era SFSymbol — agora string, pois vem do banco
   hasFile?: boolean;
+  isProcessing?: boolean;
   onUpload: () => void;
   onVer: () => void;
   onRemover: () => void;
@@ -429,10 +476,10 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
 }) {
   const { colors, isDark } = useTheme();
   // Se estiver no dark mode, vamos tornar a cor original mais suave ou manter a opacidade
-  const btnColor = color; 
+  const btnColor = color;
 
   return (
-    <Animated.View 
+    <Animated.View
       style={[styles.docCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
     >
       <View style={styles.docRow}>
@@ -472,12 +519,18 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
           </ScalePressable>
         ) : (
           <ScalePressable
-            style={[styles.actionBtnSolid, { backgroundColor: btnColor }]}
-            onPress={onUpload}
+            style={[styles.actionBtnSolid, { backgroundColor: isProcessing ? `${btnColor}80` : btnColor }]}
+            onPress={isProcessing ? undefined : onUpload}
           >
-            {/* CORRIGIDO: upload com Material Symbol no Android */}
-            <SymbolView name={sym('arrow.up.doc.fill')} size={16} tintColor="#fff" />
-            <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Upload</Text>
+            {isProcessing ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <>
+                {/* CORRIGIDO: upload com Material Symbol no Android */}
+                <SymbolView name={sym('arrow.up.doc.fill')} size={16} tintColor="#fff" />
+                <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Upload</Text>
+              </>
+            )}
           </ScalePressable>
         )}
       </View>

--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -31,7 +31,7 @@ const SYMBOL_MAP: Record<string, CrossPlatformSymbol> = {
   'trash.fill':                 { ios: 'trash.fill',                 android: 'delete',          web: 'delete' },
   'arrow.down.doc.fill':        { ios: 'arrow.down.doc.fill',        android: 'download',        web: 'download' },
   'icloud.and.arrow.up.fill':   { ios: 'icloud.and.arrow.up.fill',   android: 'cloud_upload',    web: 'cloud_upload' },
-  'vcard.fill':                 { ios: 'vcard.fill',                 android: 'badge',           web: 'badge' },
+  'person.crop.square.fill':    { ios: 'person.crop.square.fill',    android: 'badge',           web: 'badge' },
   // Ícones dos documentos (DEFAULT_DOCS)
   'doc.text.fill':              { ios: 'doc.text.fill',              android: 'description',     web: 'description' },
   'chart.bar.doc.horizontal':   { ios: 'chart.bar.doc.horizontal',   android: 'analytics',       web: 'analytics' },
@@ -65,7 +65,21 @@ const DEFAULT_DOCS = [
     description: "Documento de identificação com foto",
     meta: "",
     color: "#2563eb",
-    symbolName: "vcard.fill"
+    symbolName: "person.crop.square.fill"
+  },
+  {
+    title: "Histórico Escolar",
+    description: "Todas as disciplinas cursadas",
+    meta: "",
+    color: "#7c3aed",
+    symbolName: "books.vertical.fill"
+  },
+  {
+    title: "Passe Livre Estudantil",
+    description: "Solicitação de gratuidade no transporte",
+    meta: "",
+    color: "#be185d",
+    symbolName: "bus.fill"
   },
   {
     title: "Boletim de Notas",
@@ -82,25 +96,11 @@ const DEFAULT_DOCS = [
     symbolName: "chart.bar.doc.horizontal"
   },
   {
-    title: "Histórico Escolar",
-    description: "Todas as disciplinas cursadas",
-    meta: "",
-    color: "#7c3aed",
-    symbolName: "books.vertical.fill"
-  },
-  {
     title: "Atestado de Matrícula",
     description: "Comprovante oficial de vínculo com a UnB",
     meta: "",
     color: "#b45309",
     symbolName: "person.text.rectangle.fill"
-  },
-  {
-    title: "Passe Livre Estudantil",
-    description: "Solicitação de gratuidade no transporte",
-    meta: "",
-    color: "#be185d",
-    symbolName: "bus.fill"
   }
 ];
 

--- a/UnB-App/src/app/(tabs)/documents.tsx
+++ b/UnB-App/src/app/(tabs)/documents.tsx
@@ -30,6 +30,8 @@ const SYMBOL_MAP: Record<string, CrossPlatformSymbol> = {
   'eye.fill':                   { ios: 'eye.fill',                   android: 'visibility',      web: 'visibility' },
   'trash.fill':                 { ios: 'trash.fill',                 android: 'delete',          web: 'delete' },
   'arrow.down.doc.fill':        { ios: 'arrow.down.doc.fill',        android: 'download',        web: 'download' },
+  'icloud.and.arrow.up.fill':   { ios: 'icloud.and.arrow.up.fill',   android: 'cloud_upload',    web: 'cloud_upload' },
+  'vcard.fill':                 { ios: 'vcard.fill',                 android: 'badge',           web: 'badge' },
   // Ícones dos documentos (DEFAULT_DOCS)
   'doc.text.fill':              { ios: 'doc.text.fill',              android: 'description',     web: 'description' },
   'chart.bar.doc.horizontal':   { ios: 'chart.bar.doc.horizontal',   android: 'analytics',       web: 'analytics' },
@@ -58,6 +60,13 @@ interface DocumentRecord {
 }
 
 const DEFAULT_DOCS = [
+  {
+    title: "Carteirinha Estudantil",
+    description: "Documento de identificação com foto",
+    meta: "",
+    color: "#2563eb",
+    symbolName: "vcard.fill"
+  },
   {
     title: "Boletim de Notas",
     description: "Notas das disciplinas do semestre 2026.1",
@@ -139,7 +148,14 @@ export default function Documentos() {
   const loadDocuments = useCallback(async () => {
     try {
       await syncDefaultDocuments();
-      const result = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents ORDER BY id ASC');
+      const result = await db.getAllAsync<DocumentRecord>('SELECT * FROM documents');
+      // Ordena de acordo com o index de DEFAULT_DOCS
+      const defaultOrder = DEFAULT_DOCS.map(d => d.title);
+      result.sort((a, b) => {
+        const indexA = defaultOrder.indexOf(a.title);
+        const indexB = defaultOrder.indexOf(b.title);
+        return (indexA === -1 ? 999 : indexA) - (indexB === -1 ? 999 : indexB);
+      });
       setDocuments(result);
       const size = result.reduce((acc, curr) => acc + (curr.size || 0), 0);
       setTotalSize(size);
@@ -156,11 +172,11 @@ export default function Documentos() {
 
   const handleBaixar = async (doc: DocumentRecord) => {
     if (doc.uri && doc.uri !== "") {
-      Alert.alert('Aviso', 'O documento já foi baixado. Toque em "Ver" para acessá-lo.');
+      Alert.alert('Aviso', 'O documento já foi carregado. Toque em "Ver" para acessá-lo.');
       return;
     }
     try {
-      Alert.alert('Simulação de Download', 'Selecione um arquivo local para simular o download deste documento oficial do app da UnB.');
+      Alert.alert('Upload de Documento', 'Selecione um arquivo local para fazer o upload deste documento para o app.');
       const result = await DocumentPicker.getDocumentAsync({
         copyToCacheDirectory: true,
       });
@@ -190,13 +206,13 @@ export default function Documentos() {
       }
     } catch (error) {
       console.error(error);
-      Alert.alert('Erro', 'Não foi possível baixar/salvar o arquivo.');
+      Alert.alert('Erro', 'Não foi possível fazer o upload ou salvar o arquivo.');
     }
   };
 
   const handleVer = async (doc: DocumentRecord) => {
     if (!doc.uri || doc.uri === "") {
-      Alert.alert('Aviso', 'Este documento ainda não foi baixado.');
+      Alert.alert('Aviso', 'Este documento ainda não foi carregado.');
       return;
     }
     
@@ -469,9 +485,9 @@ function DocCard({ title, description, meta, color, symbolName, hasFile = false,
             style={[styles.actionBtnSolid, { backgroundColor: btnColor }]} 
             onPress={onBaixar}
           >
-            {/* CORRIGIDO: download com Material Symbol no Android */}
-            <SymbolView name={sym('arrow.down.doc.fill')} size={16} tintColor="#fff" />
-            <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Baixar</Text>
+            {/* CORRIGIDO: upload com Material Symbol no Android */}
+            <SymbolView name={sym('icloud.and.arrow.up.fill')} size={16} tintColor="#fff" />
+            <Text style={[styles.actionBtnSolidText, { fontSize: getFontSize(15) }]}>Upload</Text>
           </ScalePressable>
         )}
       </View>

--- a/UnB-App/utils/documentProcessor.ts
+++ b/UnB-App/utils/documentProcessor.ts
@@ -64,10 +64,10 @@ export async function processAndSaveDocument(
           [newUri, fileName || 'documento.pdf', mimeType || 'application/pdf', size || 0, newMeta, docRecord.id]
         );
 
-        // Se a chamada veio da aba Documentos (tem overrideDocId) e é um slot "burro",
+        // Se a chamada veio da aba Documentos (tem overrideDocId) e é um slot "burro" (como Carteirinha Estudantil),
         // paramos a execução aqui. Ele salva o arquivo e não altera o banco de dados.
         if (overrideDocId && docRecord.title !== "Histórico Escolar" && docRecord.title !== "Passe Livre Estudantil") {
-           return { success: false, message: 'Documento salvo (Sem Processamento Automático).' };
+           return { success: true, message: 'Documento salvo com sucesso!' };
         }
       }
     } catch (err) {

--- a/UnB-App/utils/documentProcessor.ts
+++ b/UnB-App/utils/documentProcessor.ts
@@ -24,9 +24,16 @@ export async function processAndSaveDocument(
     }
 
     const text = extractResult.text;
-    const isHistorico = text.includes('Histórico Escolar');
-    const isPasseLivre = text.includes('PASSE LIVRE ESTUDANTIL') || text.includes('Passe Livre');
     
+    // Funções lazy para não rodar todos os includes desnecessariamente
+    const checkHistorico = () => text.includes('Histórico Escolar');
+    const checkPasseLivre = () => text.includes('PASSE LIVRE ESTUDANTIL') || text.includes('Passe Livre');
+    const checkBoletim = () => text.includes('RELATÓRIO DE NOTAS') || text.includes('Boletim de Notas');
+    const checkIndice = () => text.includes('ÍNDICES ACADÊMICOS') || text.includes('Índice de Rendimento Acadêmico');
+    const checkCarteirinha = () => text.includes('VALIDADE') && (text.includes('Secretário de Administração Acadêmica') || text.includes('Secretaria de Administração Acadêmica'));
+
+    let finalDocTitle = "";
+
     // Salvar o arquivo na tabela de documentos
     try {
       let docRecord: { id: number, title: string } | null = null;
@@ -34,18 +41,38 @@ export async function processAndSaveDocument(
       if (overrideDocId) {
         docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE id = ?', [overrideDocId]);
         
-        // Validação estrita de tipo de documento
+        // Validação estrita (somente testa a regra do slot atual)
         if (docRecord) {
-           if (docRecord.title === "Histórico Escolar" && !isHistorico) {
-               return { success: false, message: 'O arquivo enviado não parece ser um Histórico Escolar. Verifique se escolheu o slot correto.' };
+           if (docRecord.title === "Histórico Escolar" && !checkHistorico()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser um Histórico Escolar. Confira se selecionou o PDF correto.' };
            }
-           if (docRecord.title === "Passe Livre Estudantil" && !isPasseLivre) {
-               return { success: false, message: 'O arquivo enviado não parece ser um Passe Livre Estudantil. Verifique se escolheu o slot correto.' };
+           if (docRecord.title === "Passe Livre Estudantil" && !checkPasseLivre()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Passe Livre Estudantil. Confira se selecionou o PDF correto.' };
            }
+           if (docRecord.title === "Boletim de Notas" && !checkBoletim()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Boletim de Notas. Confira se selecionou o PDF correto.' };
+           }
+           if (docRecord.title === "Índice Acadêmico" && !checkIndice()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser o Índice Acadêmico. Confira se selecionou o PDF correto.' };
+           }
+           if (docRecord.title === "Carteirinha Estudantil" && !checkCarteirinha()) {
+               return { success: false, message: 'O arquivo que você enviou não parece ser a Carteirinha Estudantil. Confira se selecionou o PDF correto.' };
+           }
+           finalDocTitle = docRecord.title;
         }
       } else {
-        const docTitle = isHistorico ? "Histórico Escolar" : "Passe Livre Estudantil";
-        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [docTitle]);
+        // Se inserido pelo botão genérico, testa na ordem até achar
+        if (checkHistorico()) finalDocTitle = "Histórico Escolar";
+        else if (checkPasseLivre()) finalDocTitle = "Passe Livre Estudantil";
+        else if (checkCarteirinha()) finalDocTitle = "Carteirinha Estudantil";
+        else if (checkBoletim()) finalDocTitle = "Boletim de Notas";
+        else if (checkIndice()) finalDocTitle = "Índice Acadêmico";
+        
+        if (!finalDocTitle) {
+          return { success: false, message: 'Não conseguimos identificar este documento. Por favor, envie um documento oficial gerado pelo SIGAA da UnB.' };
+        }
+
+        docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [finalDocTitle]);
       }
       
       if (docRecord) {
@@ -54,9 +81,9 @@ export async function processAndSaveDocument(
         
         let newUri = "";
         if (FileSystem) {
-          const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
-          newUri = FileSystem.documentDirectory + finalFileName;
-          await FileSystem.copyAsync({ from: fileUri, to: newUri });
+           const finalFileName = `${docRecord.id}_${fileName || 'documento.pdf'}`;
+           newUri = FileSystem.documentDirectory + finalFileName;
+           await FileSystem.copyAsync({ from: fileUri, to: newUri });
         }
 
         await db.runAsync(
@@ -64,10 +91,9 @@ export async function processAndSaveDocument(
           [newUri, fileName || 'documento.pdf', mimeType || 'application/pdf', size || 0, newMeta, docRecord.id]
         );
 
-        // Se a chamada veio da aba Documentos (tem overrideDocId) e é um slot "burro" (como Carteirinha Estudantil),
-        // paramos a execução aqui. Ele salva o arquivo e não altera o banco de dados.
-        if (overrideDocId && docRecord.title !== "Histórico Escolar" && docRecord.title !== "Passe Livre Estudantil") {
-           return { success: true, message: 'Documento salvo com sucesso!' };
+        // Bloqueia processamento indevido de documentos "burros"
+        if (finalDocTitle !== "Histórico Escolar" && finalDocTitle !== "Passe Livre Estudantil") {
+           return { success: false, message: 'Documento salvo.' };
         }
       }
     } catch (err) {
@@ -95,13 +121,13 @@ export async function processAndSaveDocument(
       return { success: true, message: successMessage };
     };
 
-    // Detecção automática de qual documento foi enviado
-    if (isHistorico) {
+    // Detecção automática de qual documento foi enviado (apenas Histórico e Passe Livre chegam aqui)
+    if (finalDocTitle === "Histórico Escolar") {
       const { extrairDadosDoHistorico } = await import('./historicoParser');
       const parsedData = extrairDadosDoHistorico(text);
       
       if (!parsedData || parsedData.disciplinas.length === 0) {
-        return { success: false, message: 'Não foi possível encontrar disciplinas válidas neste Histórico.' };
+        return { success: false, message: 'Conseguimos ler o Histórico, mas não encontramos nenhuma disciplina cursada nele.' };
       }
 
       // Descobrir qual é o semestre atual (o maior ano/periodo do histórico)
@@ -153,12 +179,12 @@ export async function processAndSaveDocument(
       // Se não for Histórico, assume que é Passe Livre
       const { aluno, disciplinas: parsedDisciplinas } = extrairDadosDoPDF(text);
       if (parsedDisciplinas.length === 0) {
-        return { success: false, message: 'Não foi possível encontrar disciplinas válidas neste PDF.' };
+        return { success: false, message: 'Conseguimos ler o Passe Livre, mas não encontramos nenhuma disciplina matriculada.' };
       }
 
       return await attemptSync(aluno, parsedDisciplinas, 'Grade importada com sucesso via Declaração/Passe Livre! O arquivo foi salvo na aba Documentos.');
     }
   } catch (error: any) {
-    return { success: false, message: `Erro ao processar o arquivo: ${error.message}` };
+    return { success: false, message: `Ocorreu um erro inesperado ao processar o arquivo: ${error.message}` };
   }
 }


### PR DESCRIPTION
# Adição da Carteirinha Estudantil, Refatoração e Sincronização do Upload de Documentos

## 📝 Descrição
Este Pull Request implementa a inclusão da Carteirinha Estudantil na aba de documentos, refatora a lógica de extração e validação do `documentProcessor`, melhora a UX adicionando indicadores de carregamento durante uploads pesados, e padroniza a sincronização do Perfil de Usuário com a aba de Disciplinas.

## 🛠 Modificações Realizadas

### 1. `documents.tsx`
- **Carteirinha Estudantil:** Adicionada como a primeira opção (no topo) na constante `DEFAULT_DOCS`, utilizando a descrição "Comprovante oficial de vínculo com a UnB".
- **Ícone e Estilização:** O Atestado de Matrícula foi removido; seu ícone base (`person.text.rectangle.fill`) foi reaproveitado para a carteirinha. O botão de ação agora possui a label "Upload" (em vez de "Baixar") com um ícone de nuvem (`arrow.up.doc.fill`) para as opções pendentes.
- **Loading State (UX):** Embora o processamento nativo de leitura de PDFs costume ser muito rápido, foi adicionado um `ActivityIndicator` (loading circular) nos botões de Upload como precaução. Ele é ativado e desativado pelas variáveis de estado locais para evitar que o app pareça travado ou congelado caso ocorra qualquer lentidão na leitura ou no banco de dados (especialmente em dispositivos mais antigos ou com históricos enormes).
- **Sincronização de Contexto:** Adicionado o uso do `UserProfileContext` ao botão de Upload, implementando a mesma regra de negócio da aba de Disciplinas:
   - Alerta o usuário caso ele insira um documento que não corresponda à sua própria matrícula.
   - Pergunta proativamente se o usuário deseja mudar os dados do seu perfil atual com base nas informações encontradas no arquivo novo.
   - Força uma atualização global via `updateUserProfile`, permitindo que todas as abas (`index.tsx` e `disciplinas.tsx`) espelhem imediatamente os dados processados do SQLite sem necessitar de um recarregamento da aplicação inteira.

### 2. `documentProcessor.ts`
- **Refatoração Lazy:** Validações do tipo do documento foram otimizadas usando funções de checagem condicional (`checkHistorico = () => text.includes(...)`), poupando execuções redundantes para strings longas.
- **Validação de Slot Estrita (`overrideDocId`):** Quando o usuário faz um upload por um botão direcionado (ex. o bloco do Passe Livre), o processador inspeciona a string do PDF rigorosamente para checar se ele de fato equivale ao tipo daquele bloco. Retorna um erro customizado nos casos que não baterem.
- **Documentos Estáticos ("Burros"):** Documentos como Índice, Carteirinha e Boletim ignoram a cadeia de dependência de `gradeQueries`, ou seja, são apenas copiados para a cache e mostrados, mas jamais acionam recadastramento ou manipulação de turmas/período por debaixo dos panos. 

### 3. `disciplinas.tsx`
- **Gatilho de Transição:** O `useFocusEffect` (do `expo-router`) foi restaurado no lugar do simples `useEffect` fixo, o que garante que a função `carregarDisciplinas()` verifique novamente o Banco de Dados (SQLite) a cada transição para esta aba. 

## 🧪 Como testar
1. Limpe o banco de dados (se necessário) para resetar o layout inicial com a nova *Carteirinha Estudantil*.
2. Na aba **Documentos**, faça upload de um Histórico Escolar ou Passe Livre e aguarde até a mensagem de sucesso.
3. Tente enviar um histórico em que a matrícula **não** bata com o seu usuário global (para testar a janela `Documento Inconsistente`).
4. Após o *upload*, navegue imediatamente para a aba **Disciplinas** ou **Início** e corrobore que as novas matérias foram preenchidas sem que tenha sido necessário reiniciar o aplicativo, provando a eficácia do uso conjugado de `useFocusEffect` e `updateUserProfile`.

---

> Submetido para revisão em `feat/validacao-carteirinha-v2`.
