### PR TITLE
Fix(documentos/grade): Garante slots de documentos no primeiro acesso e impede mescla de turmas trancadas

### DIFF
--- a/UnB-App/database/dbinit.ts
+++ b/UnB-App/database/dbinit.ts
@@ -112,4 +112,26 @@ export async function initializeDatabase(db: SQLiteDatabase) {
   } catch (error) {
     console.error('Falha ao inicializar banco de dados:', error);
   }
+
+  // Ensure default documents exist
+  try {
+    const existingDocs = await db.getAllAsync('SELECT id FROM documents LIMIT 1');
+    if (existingDocs.length === 0) {
+      const DEFAULT_DOCS = [
+        { title: "Carteirinha Estudantil", description: "Comprovante oficial de vínculo com a UnB", meta: "", color: "#b45309", symbolName: "person.text.rectangle.fill" },
+        { title: "Histórico Escolar", description: "Todas as disciplinas cursadas", meta: "", color: "#7c3aed", symbolName: "books.vertical.fill" },
+        { title: "Passe Livre Estudantil", description: "Solicitação de gratuidade no transporte", meta: "", color: "#be185d", symbolName: "bus.fill" },
+        { title: "Boletim de Notas", description: "Notas das disciplinas do semestre 2026.1", meta: "", color: "#1d8d28", symbolName: "doc.text.fill" },
+        { title: "Índice Acadêmico", description: "IRA, IECH e CR consolidados", meta: "", color: "#0e7490", symbolName: "chart.bar.doc.horizontal" }
+      ];
+      for (const doc of DEFAULT_DOCS) {
+        await db.runAsync(
+          'INSERT INTO documents (title, description, meta, color, symbolName, uri) VALUES (?, ?, ?, ?, ?, ?)',
+          [doc.title, doc.description, doc.meta, doc.color, doc.symbolName, ""]
+        );
+      }
+    }
+  } catch (e) {
+    console.error('Falha ao inserir documentos padrão:', e);
+  }
 }

--- a/UnB-App/database/queries/gradeQueries.ts
+++ b/UnB-App/database/queries/gradeQueries.ts
@@ -111,8 +111,8 @@ export async function popularGradePorDados(
 
       // Checa se a turma já existe para este aluno neste semestre
       let idTurma: number | undefined;
-      const turmaExistente = await db.getFirstAsync<{ id_turma: number }>(
-        `SELECT t.id_turma 
+      const turmasExistentes = await db.getAllAsync<{ id_turma: number, numero_turma: string, situacao: string }>(
+        `SELECT t.id_turma, t.numero_turma, ta.situacao
          FROM Turma t 
          LEFT JOIN Turma_Aluno ta ON t.id_turma = ta.id_turma 
          WHERE t.codigo_disciplina = ? AND t.ano = ? AND t.periodo = ? 
@@ -120,13 +120,28 @@ export async function popularGradePorDados(
         [item.codigo, turmaAno, turmaPeriodo, matricula]
       );
 
-      if (turmaExistente) {
-        idTurma = turmaExistente.id_turma;
-        
-        if (item.turma && item.turma !== '00' && item.turma !== '01' && item.turma !== '--') {
-           await db.runAsync('UPDATE Turma SET numero_turma = ? WHERE id_turma = ?', [item.turma, idTurma]);
+      if (turmasExistentes.length > 0) {
+        let match = turmasExistentes.find(t => 
+             (t.situacao === situacao && (t.numero_turma === item.turma || t.numero_turma === '--' || item.turma === '--' || t.numero_turma === '00' || item.turma === '00')) ||
+             (t.numero_turma === item.turma && item.turma !== '--' && item.turma !== '00')
+        );
+
+        if (!match && turmasExistentes.length === 1) {
+            const t = turmasExistentes[0];
+            if (t.numero_turma === '--' || t.numero_turma === '00' || item.turma === '--' || item.turma === '00') {
+                match = t;
+            }
         }
-      } else {
+
+        if (match) {
+           idTurma = match.id_turma;
+           if (item.turma && item.turma !== '00' && item.turma !== '01' && item.turma !== '--') {
+              await db.runAsync('UPDATE Turma SET numero_turma = ? WHERE id_turma = ?', [item.turma, idTurma]);
+           }
+        }
+      }
+
+      if (!idTurma) {
         await db.runAsync(
           'INSERT INTO Turma (codigo_disciplina, numero_turma, ano, periodo) VALUES (?, ?, ?, ?)',
           [item.codigo, item.turma, turmaAno, turmaPeriodo]

--- a/UnB-App/utils/documentProcessor.ts
+++ b/UnB-App/utils/documentProcessor.ts
@@ -31,9 +31,27 @@ export async function processAndSaveDocument(
     const checkIndice = () => text.includes('ÍNDICES ACADÊMICOS') || text.includes('Índice de Rendimento Acadêmico');
     const checkCarteirinha = () => text.includes('VALIDADE') && (text.includes('Secretário de Administração Acadêmica') || text.includes('Secretaria de Administração Acadêmica'));
 
+    let docRecord: { id: number, title: string } | null = null;
+
     // Salvar o arquivo na tabela de documentos
     try {
-      let docRecord: { id: number, title: string } | null = null;
+      // Garante que os slots padrão existam (caso o banco tenha sido limpo recentemente)
+      const existingDocs = await db.getAllAsync('SELECT id FROM documents LIMIT 1');
+      if (existingDocs.length === 0) {
+        const DEFAULT_DOCS = [
+          { title: "Carteirinha Estudantil", description: "Comprovante oficial de vínculo com a UnB", meta: "", color: "#b45309", symbolName: "person.text.rectangle.fill" },
+          { title: "Histórico Escolar", description: "Todas as disciplinas cursadas", meta: "", color: "#7c3aed", symbolName: "books.vertical.fill" },
+          { title: "Passe Livre Estudantil", description: "Solicitação de gratuidade no transporte", meta: "", color: "#be185d", symbolName: "bus.fill" },
+          { title: "Boletim de Notas", description: "Notas das disciplinas do semestre 2026.1", meta: "", color: "#1d8d28", symbolName: "doc.text.fill" },
+          { title: "Índice Acadêmico", description: "IRA, IECH e CR consolidados", meta: "", color: "#0e7490", symbolName: "chart.bar.doc.horizontal" }
+        ];
+        for (const doc of DEFAULT_DOCS) {
+          await db.runAsync(
+            'INSERT INTO documents (title, description, meta, color, symbolName, uri) VALUES (?, ?, ?, ?, ?, ?)',
+            [doc.title, doc.description, doc.meta, doc.color, doc.symbolName, ""]
+          );
+        }
+      }
 
       if (overrideDocId) {
         docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE id = ?', [overrideDocId]);
@@ -57,6 +75,9 @@ export async function processAndSaveDocument(
            }
         }
       } else {
+        if (!checkHistorico() && !checkPasseLivre()) {
+          return { success: false, message: 'Por aqui, só é possível importar a sua grade pelo Histórico Escolar ou pelo Passe Livre Estudantil.' };
+        }
         const docTitle = checkHistorico() ? "Histórico Escolar" : "Passe Livre Estudantil";
         docRecord = await db.getFirstAsync<{id: number, title: string}>('SELECT id, title FROM documents WHERE title = ?', [docTitle]);
       }
@@ -99,6 +120,36 @@ export async function processAndSaveDocument(
 
       if (!proceed) {
          return { success: false, message: 'Importação cancelada pelo usuário.' };
+      }
+
+      const currentAluno = await db.getFirstAsync<{ matricula: string }>('SELECT matricula FROM Aluno LIMIT 1');
+      if (currentAluno && currentAluno.matricula !== alunoInfo.matricula && shouldSync) {
+        // Troca de usuário confirmada: apagar documentos do usuário antigo (exceto o recém-inserido)
+        const docsToDelete = await db.getAllAsync<{ uri: string }>('SELECT uri FROM documents WHERE id != ? AND uri != ""', [docRecord?.id || 0]);
+        for (const doc of docsToDelete) {
+           if (doc.uri && FileSystem) {
+              try {
+                 const fileInfo = await FileSystem.getInfoAsync(doc.uri);
+                 if (fileInfo.exists) {
+                    await FileSystem.deleteAsync(doc.uri);
+                 }
+              } catch (e) {
+                 console.error('Erro ao deletar arquivo antigo:', e);
+              }
+           }
+        }
+        
+        if (docRecord) {
+           await db.runAsync(
+              'UPDATE documents SET uri = ?, fileName = ?, mimeType = ?, size = ?, meta = ? WHERE id != ?',
+              ["", null, null, null, "", docRecord.id]
+           );
+        } else {
+           await db.runAsync(
+              'UPDATE documents SET uri = ?, fileName = ?, mimeType = ?, size = ?, meta = ?',
+              ["", null, null, null, ""]
+           );
+        }
       }
 
       await popularGradePorDados(db, alunoInfo, disciplinasFormatadas, shouldSync);


### PR DESCRIPTION
Este Pull Request aplica correções críticas na persistência de dados do usuário e na sincronização da grade horária a partir de PDFs. Foram resolvidos cenários de borda que causavam falhas no salvamento do primeiro documento enviado ou na limpeza de documentos residuais após a troca de perfil. Além disso, o motor de correspondência de turmas foi otimizado para evitar a mescla indevida de dados de disciplinas em que o aluno possua múltiplas situações no mesmo semestre (ex: Turma Trancada vs Turma Matriculada).

🚀 O que foi alterado?

**Garantia de Persistência e Limpeza de Documentos (dbinit.ts & documentProcessor.ts):**
* Implementado um fallback estratégico que garante a criação imediata dos slots de documentos (Histórico, Passe Livre, etc.) caso a tabela esteja vazia durante o primeiro envio, seja após a instalação ou após o uso da opção "Limpar todos os dados".
* Adicionada limpeza física (via `FileSystem`) e no banco de dados dos PDFs do usuário antigo ao confirmar uma nova sincronização de perfil (preservando apenas o documento atual recém-imporado).
* Validação estrita inserida na aba Disciplinas: o sistema agora recusa prontamente arquivos que não sejam o Histórico Escolar ou o Passe Livre.

**Refinamento da Sincronização de Grade e Turmas (gradeQueries.ts):**
* Ajuste na lógica de mescla da função `turmaExistente`. Agora o extrator de PDF diferencia e separa duas turmas da mesma disciplina no mesmo semestre caso a `situacao` da matrícula (TRANC/MATR) ou o `numero_turma` sejam divergentes.
* Turmas trancadas agora ganham um ID próprio, isolando-as no histórico do aluno e impedindo que seus docentes "vazem" e sejam listados na turma em que o aluno está atualmente matriculado.

🎯 Requisitos Atendidos

* RF04 - Armazenar Dados de Documentos Enviados
* RF05 - Processar Dados de Documentos Enviados
* RNF08 - Armazenar Dados Locais com Expo SQLite

🧪 Como Testar

1. Limpe os dados do aplicativo na aba de configurações. 
2. Acesse a aba **Disciplinas** primeiro (antes da aba Documentos) e tente enviar um Histórico Escolar. O documento deve ser salvo perfeitamente na primeira tentativa.
3. Tente enviar um Boletim de Notas pela aba **Disciplinas**. O App deve bloquear a importação e exibir a mensagem informando que apenas Histórico ou Passe Livre são aceitos ali.
4. Faça o upload de um documento válido de **outra** matrícula e aceite a sincronização. Na aba Documentos, verifique se os documentos residuais do usuário anterior foram apagados, mantendo apenas o recém-inserido.
5. Verifique a tela principal de **Disciplinas** usando um Histórico de aluno que possui disciplinas *trancadas* e *matriculadas* na mesma matéria no mesmo semestre. Certifique-se de que a tela não está mais listando os professores da turma trancada na turma atual.
